### PR TITLE
Clean up synonyms and xrefs

### DIFF
--- a/experimental_condition.obo
+++ b/experimental_condition.obo
@@ -5663,9 +5663,9 @@ creation_date: 2019-03-27T15:52:55Z
 id: XCO:0000611
 name: nifedipine
 def: "Nifedipine is a potent vasodilator agent with calcium antagonistic action. It is a useful anti-anginal agent that also lowers blood pressure." [https://meshb.nlm.nih.gov/record/ui?ui=D009543 "MESH"]
-synonym: "CHEBI:7565" EXACT []
 synonym: "Pubchem: 4485" EXACT []
 is_a: XCO:0000269 ! calcium channel inhibitor
+xref: CHEBI:7565
 created_by: sjwang
 creation_date: 2019-04-22T16:41:50Z
 

--- a/experimental_condition.obo
+++ b/experimental_condition.obo
@@ -641,7 +641,7 @@ synonym: "7,12-DMBA" RELATED []
 synonym: "9,10-Dimethyl-1,2-benzanthracene" RELATED []
 synonym: "DMBA" RELATED []
 xref: CHEBI:254496
-xref: MeSH:D015127
+xref: MESH:D015127
 is_a: XCO:0000093 ! polycyclic arene
 created_by: mshimoyama
 creation_date: 2010-11-01T01:01:46Z
@@ -660,7 +660,7 @@ id: XCO:0000092
 name: 17 beta-estradiol
 def: "The predominant circulating form of estrogen, the female sex hormone." [http://en.wikipedia.org/wiki/Estradiol "Wikipedia"]
 synonym: "beta-estradiol" RELATED []
-synonym: "CHEBI:16469" RELATED []
+xref: CHEBI:16469
 synonym: "CO47085" RELATED []
 synonym: "E2" RELATED []
 synonym: "estradiol" RELATED []
@@ -911,12 +911,12 @@ creation_date: 2012-02-16T01:09:21Z
 [Term]
 id: XCO:0000121
 name: NG-nitroarginine methyl ester
-def: "A basic amino acid, commonly known as L-NAME, used as a non-selective inhibitor of nitric oxide synthase." [MeSH:D019331]
-synonym: "CAS 51298-62-5" RELATED []
-synonym: "CHEMBL7890" RELATED []
+def: "A basic amino acid, commonly known as L-NAME, used as a non-selective inhibitor of nitric oxide synthase." [MESH:D019331]
+xref: CAS:51298-62-5
+xref: chembl.compound:CHEMBL7890
 synonym: "L-NAME" EXACT []
-synonym: "MeSH:D019331" RELATED []
-synonym: "PubChem_Compound_CID:39836" RELATED []
+synonym: "MESH:D019331" RELATED []
+xref: pubchem.compound:39836
 is_a: XCO:0000119 ! amino acid
 is_a: XCO:0000523 ! enzyme inhibitor
 created_by: JSmith
@@ -934,7 +934,6 @@ creation_date: 2012-02-16T01:51:41Z
 id: XCO:0000123
 name: sulfonamide
 def: "A compound containing a sulfonamide functional group. A sulfonamide functional group contains sulfonyl connected to an amine group and has the general structure R-S(=O)2-NH2. Sulfonamide also refers to several classes of drugs which include antimicrobial 'sulfa drugs', anticonvulsants and the sulfonylureas and thiazide diuretics." [http://en.eikipedia.org/wiki/ "Wikipedia"]
-synonym: "CHEBI:35358" RELATED []
 xref: CHEBI:35358
 is_a: XCO:0000342 ! chemical with specified structure
 is_a: XCO:0000950 ! anticonvulsant
@@ -947,7 +946,7 @@ name: furosemide
 def: "A diuretic drug which inhibits Nkcc2, one of the Na-K symporters and reduces the reabsorption of sodium chloride.  Furosemide is used experimentally for sodium depletion." [http://en.eikipedia.org/wiki/ "Wikipedia"]
 synonym: "Frusemide" RELATED []
 synonym: "Lasix" RELATED []
-synonym: "PubChem_Compound_CID:3440" RELATED []
+xref: pubchem.compound:3440
 xref: CHEBI:47426
 is_a: XCO:0000122 ! diuretic
 is_a: XCO:0000123 ! sulfonamide
@@ -1002,8 +1001,8 @@ creation_date: 2012-02-16T03:23:57Z
 id: XCO:0000130
 name: ketamine
 def: "An analgesic and anesthetic which functions as a noncompetitive NMDA receptor (NMDAR) antagonist, binding to the allosteric site of the NMDA receptor and effectively inhibiting its channel." [http://en.wikipedia.org/wiki/Ketamine "Wikipedia"]
+xref: pubchem.compound:3821
 xref: CHEBI:6121
-xref: CID:3821
 is_a: XCO:0000947 ! NMDA receptor antagonist
 created_by: JSmith
 creation_date: 2012-03-15T07:33:06Z
@@ -1012,9 +1011,9 @@ creation_date: 2012-03-15T07:33:06Z
 id: XCO:0000131
 name: xylazine
 def: "An alpha2-adrenergic receptor agonist used for sedation, anesthesia, muscle relaxation, and analgesia in animals." [http://en.wikipedia.org/wiki/Xylazine "Wikipedia"]
-synonym: "PubChem_Compound_CID:5707" RELATED []
+xref: pubchem.compound:5707
 xref: CHEBI:165540
-xref: CHEMBL:297362
+xref: chembl.compound:CHEMBL297362
 is_a: XCO:0000106 ! anesthetic/analgesic
 created_by: JSmith
 creation_date: 2012-03-15T07:34:39Z
@@ -1023,7 +1022,7 @@ creation_date: 2012-03-15T07:34:39Z
 id: XCO:0000132
 name: acepromazine
 def: "A phenothiazine-derivative antipsychotic drug used in animals as a sedative and antiemetic and which can also cause peripheral vasodilation." [http://en.wikipedia.org/wiki/Acepromazine "Wikipedia"]
-synonym: "PubChem_Compound_CID:6077" RELATED []
+xref: pubchem.compound:6077
 xref: CHEBI:44932
 is_a: XCO:0000106 ! anesthetic/analgesic
 created_by: JSmith
@@ -1067,7 +1066,7 @@ name: FAPGG
 def: "An oligopeptide substrate for continuous spectrophotometric assay of angiotensin converting enzyme (ACE) which hydrolyzes FAPGG to furylacryloylphenylalanine (FAP) and glycylglycine with a resulting decrease in absorbance at 340 nm." [http://www.sigmaaldrich.com/catalog/product/sigma/f7131?lang=en&region=US "Website", http://www.trinitybiotech.com/Product%20Documents/305-10-29%20EN.pdf "Website"]
 synonym: "3-(2-FurylAcryloyl)-L-PHE-GLY-GLY" EXACT []
 synonym: "FurylAcrylolPhenylalanylGlycylGlycine" EXACT []
-synonym: "PubChem_Compound_CID:6438387" RELATED []
+xref: pubchem.compound:6438387
 xref: CAS:64566-61-6
 is_a: XCO:0000136 ! enzyme substrate
 created_by: JSmith
@@ -1078,7 +1077,7 @@ id: XCO:0000138
 name: methylene blue
 def: "Methylene blue is monoamine oxidase inhibitor and nitric oxide synthase inhibitor, as well as a cationic dye used as a redox indicator." [RGD:SL]
 synonym: "methylthioninium chloride" EXACT []
-synonym: "PubChem_Compound_CID:6099" RELATED []
+xref: pubchem.compound:6099
 xref: CHEBI:6872
 is_a: XCO:0000199 ! oxidation-reduction indicator
 is_a: XCO:0000523 ! enzyme inhibitor
@@ -1115,8 +1114,8 @@ id: XCO:0000142
 name: sodium nitroprusside
 def: "The red-coloured inorganic salt with the formula Na2[Fe(CN)5NO]·2H2O used as a potent vasodilator." [http://en.wikipedia.org/wiki/Sodium_nitroprusside "Wikipedia"]
 synonym: "disodium pentacyanonitrosylferrate(2-) dehydrate" EXACT []
-synonym: "PubChem_Compound_CID:11953891" RELATED []
-synonym: "PubChem_Compound_CID:11963579" RELATED []
+xref: pubchem.compound:11953891
+xref: pubchem.compound:11963579
 synonym: "sodium nitroferricyanide" EXACT []
 xref: CHEBI:29321
 is_a: XCO:0000140 ! vasodilator
@@ -1127,7 +1126,7 @@ creation_date: 2012-03-15T07:58:24Z
 id: XCO:0000143
 name: acetylcholine
 def: "An organic, polyatomic cation, formed as an ester of acetic acid and choline, that acts as a neurotransmitter in both the peripheral nervous system (PNS) and central nervous system (CNS) in many organisms." [http://en.wikipedia.org/wiki/Acetylcholine "Wikipedia"]
-synonym: "PubChem_Compound_CID:187" RELATED []
+xref: pubchem.compound:187
 xref: CHEBI:15355
 is_a: XCO:0000140 ! vasodilator
 is_a: XCO:0000144 ! neurotransmitter
@@ -1145,7 +1144,7 @@ creation_date: 2012-03-15T08:01:41Z
 id: XCO:0000145
 name: phenylephrine
 def: "A selective alpha1-adrenergic receptor agonist used primarily as a decongestant, as an agent to dilate the pupil, and as a vasoconstrictor." [http://en.wikipedia.org/wiki/Phenylephrine "Wikipedia"]
-synonym: "PubChem_Compound_CID:6041" RELATED []
+xref: pubchem.compound:6041
 xref: CHEBI:8093
 is_a: XCO:0000141 ! vasoconstrictor
 is_a: XCO:0000673 ! alpha-adrenergic agonist
@@ -1521,7 +1520,7 @@ name: cytisine
 def: "A toxic selective nicotinic cholinergic alkaloid from the seed of Laburnum anagyroides and other Leguminosae. Used in pharmacological studies of nicotinic cholinergic receptors in the brain." [Mondofacto:Mondofacto_Online_Medical_Dictionary]
 synonym: "baptitoxine" RELATED []
 synonym: "sophorine" RELATED []
-xref: CASRN:485-35-8
+xref: CAS:485-35-8
 is_a: XCO:0000693 ! cholinergic agonist
 created_by: JSmith
 creation_date: 2012-07-30T08:40:00Z
@@ -1532,7 +1531,7 @@ name: trimethaphan camsylate
 def: "A drug that counteracts cholinergic transmission at the ganglion type of nicotinic receptors of the autonomic ganglia by acting as a non-depolarizing competitive antagonist at the nicotinic acetylcholine receptor." [http://en.wikipedia.org/wiki/Trimethaphan_camsylate "Wikipedia"]
 synonym: "Arfonad" RELATED []
 synonym: "trimetaphan camsilate" EXACT []
-xref: CASRN:7187-66-8
+xref: CAS:7187-66-8
 xref: CHEBI:9729
 is_a: XCO:0000630 ! cholinergic antagonist
 created_by: JSmith
@@ -1543,7 +1542,7 @@ id: XCO:0000188
 name: darodipine
 def: "Calcium channel blocker." [http://en.wikipedia.org/wiki/Darodipine "Wikipedia"]
 synonym: "PY 108-068" RELATED []
-xref: CASRN:72803-02-2
+xref: CAS:72803-02-2
 is_a: XCO:0000269 ! calcium channel inhibitor
 created_by: JSmith
 creation_date: 2012-07-30T09:01:57Z
@@ -1658,7 +1657,7 @@ synonym: "4-methyl-2-oxovaleric acid" EXACT []
 synonym: "alpha-ketoisocaproic acid" EXACT []
 synonym: "alpha-KIC" RELATED []
 synonym: "Ketoleucine" RELATED []
-synonym: "PubChem_Compound_CID:70" RELATED []
+xref: pubchem.compound:70
 xref: CHEBI:48430
 is_a: XCO:0000136 ! enzyme substrate
 created_by: JSmith
@@ -1732,10 +1731,10 @@ def: "A condition in which the main influencing factor is 3-methyl-4'-dimethylam
 synonym: "3'-Me-DAB" RELATED []
 synonym: "3'-methyl-4-(dimethylamino)azobenzene" RELATED []
 synonym: "4-Dimethylamino-3'-methylazobenzene" EXACT []
-synonym: "CAS_RN:55-80-1" RELATED []
+xref: CAS:55-80-1
 synonym: "MDAB" RELATED []
 synonym: "methyldimethylaminoazobenzene" EXACT []
-synonym: "PubChem_Compound_CID:5934" RELATED []
+xref: pubchem.compound:5934
 xref: CHEBI:76329
 is_a: XCO:0000089 ! neoplasm-inducing chemical
 created_by: JSmith
@@ -1840,7 +1839,7 @@ id: XCO:0000218
 name: 4-alpha-phorbol 12,13-didecanoate
 def: "A phorbol ester analog that is an activator of TRPV4 (transient receptor potential cation channel, subfamily V, member 4) channels." [http://www.lclabs.com/PRODFILE/P-R/P-2170.php4 "Website"]
 synonym: "4-alpha-PDD" EXACT []
-synonym: "PubChem_Compound_CID:452544" RELATED []
+xref: pubchem.compound:452544
 xref: CHEBI:295732
 is_a: XCO:0000217 ! cation channel activator
 created_by: JSmith
@@ -1917,7 +1916,7 @@ id: XCO:0000226
 name: apamin
 def: "An 18 amino acid peptide neurotoxin from bee venom which blocks small-conductance Ca2+-activated K+ channels." [http://en.wikipedia.org/wiki/Apamin "Wikipedia"]
 synonym: "apamine" EXACT []
-synonym: "PubChem_Compound_CID:16129677" RELATED []
+xref: pubchem.compound:16129677
 xref: UniProtKB:P01500
 is_a: XCO:0000225 ! potassium channel inhibitor
 created_by: JSmith
@@ -2073,7 +2072,7 @@ synonym: "2,4,5,6-pyrimidinetetrone" EXACT []
 synonym: "5-Oxobarbituric acid" EXACT []
 synonym: "alloxane" EXACT []
 synonym: "mesoxalylurea" EXACT []
-synonym: "PubChem_Compound_CID:5781" RELATED []
+xref: pubchem.compound:5781
 is_a: XCO:0000239 ! toxic substance
 is_a: XCO:0000885 ! diabetes-inducing chemical
 created_by: JSmith
@@ -2270,7 +2269,7 @@ name: pristane
 def: "A condition in which the major influencing factor is an acyclic saturated hydrocarbon derived from phytane by loss of its C-16 terminal methyl group." []
 synonym: "2,6,10,14-tetramethylpentadecane" EXACT []
 xref: CHEBI:53181
-xref: MeSH:C009042
+xref: MESH:C009042
 is_a: XCO:0000133 ! antigen
 is_a: XCO:0000261 ! arthritis inducing chemical
 created_by: JSmith
@@ -2361,7 +2360,7 @@ synonym: "4-hydroxy-2,2,6,6-tetramethylpiperidin-1-oxyl" RELATED []
 synonym: "4-Oxypiperidol" RELATED []
 synonym: "HyTEMPO" RELATED []
 synonym: "Nitroxyl-2" RELATED []
-synonym: "PubChem_Compound_CID:137994" RELATED []
+xref: pubchem.compound:137994
 synonym: "Tanol" RELATED []
 synonym: "TMPN" RELATED []
 is_a: XCO:0000271 ! antioxidant
@@ -2433,7 +2432,7 @@ def: "A triterpene, that is a terpine containing six isoprene units, consisting 
 synonym: "Spinacene" RELATED []
 synonym: "Supraene" RELATED []
 xref: CHEBI:15440
-xref: MeSH:D013185
+xref: MESH:D013185
 is_a: XCO:0000279 ! terpene
 created_by: JSmith
 creation_date: 2013-03-12T17:25:17Z
@@ -2479,7 +2478,7 @@ creation_date: 2013-03-13T12:12:45Z
 [Term]
 id: XCO:0000285
 name: controlled NG-nitroarginine methyl ester content drinking water
-def: "A drink made up of water and a specified amount of the basic amino acid commonly known as L-NAME and used as a non-selective inhibitor of nitric oxide synthase, consumed by an organism as part of an experiment." [Dorland:Dorlands_Illustrated_Medical_Dictionary--31st_Ed, ISBN:978-1416049982, MeSH:D019331]
+def: "A drink made up of water and a specified amount of the basic amino acid commonly known as L-NAME and used as a non-selective inhibitor of nitric oxide synthase, consumed by an organism as part of an experiment." [Dorland:Dorlands_Illustrated_Medical_Dictionary--31st_Ed, ISBN:978-1416049982, MESH:D019331]
 synonym: "controlled L-NAME content water" EXACT []
 is_a: XCO:0000163 ! controlled content drinking water
 relationship: has_component XCO:0000121 ! NG-nitroarginine methyl ester
@@ -2829,8 +2828,8 @@ creation_date: 2013-06-25T16:08:47Z
 id: XCO:0000320
 name: hexamethonium
 def: "Either of two compounds (C12H30Br2N2 or C12H30Cl2N2) used in the treatment of hypertension. Hexamethonium is a depolarising ganglionic blocker, a nicotinic acetylcholine receptor antagonist that acts in autonomic ganglia by binding in or on the receptor but not the acetylcholine binding site itself." [http://en.wikipedia.org/wiki/Hexamethonium "Wikipedia", Merriam-Webster:Merriam-Websters_Online_Dictionary--11th_Ed]
-synonym: "PubChem_Compound:CID_3604" RELATED []
-xref: CHEMBL:105608
+xref: pubchem.compound:3604
+xref: chembl.compound:CHEMBL105608
 is_a: XCO:0000160 ! receptor antagonist
 created_by: JSmith
 creation_date: 2013-06-25T17:12:45Z
@@ -2840,8 +2839,8 @@ id: XCO:0000321
 name: hexamethonium bromide
 def: "The compound C12H30Br2N2, consisting of a hexamethonium cation and dibromide anion, used in the treatment of hypertension. Hexamethonium is a depolarising ganglionic blocker, a nicotinic acetylcholine receptor antagonist that acts in autonomic ganglia by binding in or on the receptor but not the acetylcholine binding site itself." [http://en.wikipedia.org/wiki/Hexamethonium "Wikipedia", Merriam-Webster:Merriam-Websters_Online_Dictionary--11th_Ed]
 synonym: "hexamethonium dibromide" RELATED []
-synonym: "PubChem_Compound:CID_5938" RELATED []
-xref: CHEMBL:105608
+xref: pubchem.compound:5938
+xref: chembl.compound:CHEMBL105608
 is_a: XCO:0000320 ! hexamethonium
 created_by: JSmith
 creation_date: 2013-06-25T17:17:10Z
@@ -2851,8 +2850,8 @@ id: XCO:0000322
 name: hexamethonium chloride
 def: "The compound C12H30Cl2N2, consisting of a hexamethonium cation and dichloride anion, used in the treatment of hypertension. Hexamethonium is a depolarising ganglionic blocker, a nicotinic acetylcholine receptor antagonist that acts in autonomic ganglia by binding in or on the receptor but not the acetylcholine binding site itself." [http://en.wikipedia.org/wiki/Hexamethonium "Wikipedia", Merriam-Webster:Merriam-Websters_Online_Dictionary--11th_Ed]
 synonym: "hexamethonium dichloride" RELATED []
-synonym: "PubChem_Compound:CID_93550" RELATED []
-xref: CHEMBL:105608
+xref: pubchem.compound:93550
+xref: chembl.compound:CHEMBL105608
 is_a: XCO:0000320 ! hexamethonium
 created_by: JSmith
 creation_date: 2013-06-25T17:19:38Z
@@ -2942,7 +2941,7 @@ id: XCO:0000331
 name: RU28362
 def: "Any condition in which the main influencing factor is RU28362, a highly selective neuroactive agonist of the glucocorticoid (Corticoid Type II) receptor, but not of the mineralocorticoid (Corticoid Type I) receptor." [http://en.wikipedia.org/wiki/RU28362 "Wikipedia", http://www.nursa.org/molecule.cfm?molType=ligand&molId=1123 "Website"]
 synonym: "11,17-dihydroxy-6-methyl-17-(1-propynyl)androsta-1,4,6-triene-3-one" EXACT []
-synonym: "PubChem_Compound: CID 123790" RELATED []
+xref: pubchem.compound:123790
 is_a: XCO:0000135 ! receptor agonist
 created_by: jsmith
 creation_date: 2013-08-22T14:49:55Z
@@ -3069,7 +3068,7 @@ creation_date: 2013-09-04T13:12:02Z
 [Term]
 id: XCO:0000344
 name: N-propyl-N-nitrosourea
-def: "Any condition in which the main influencing factor is a chemical with three major moieties, a propyl group (a linear three-carbon alkyl substituent with chemical formula -C3H7), a nitroso group (R-N=O) and a urea group (two -NH2 groups joined by a carbonyl (C=O) functional group)." [http://en.wikipedia.org/wiki/Nitrosourea "Wikipedia", http://en.wikipedia.org/wiki/Propyl "Wikipedia", PubChem_Compound:CID_13157]
+def: "Any condition in which the main influencing factor is a chemical with three major moieties, a propyl group (a linear three-carbon alkyl substituent with chemical formula -C3H7), a nitroso group (R-N=O) and a urea group (two -NH2 groups joined by a carbonyl (C=O) functional group)." [http://en.wikipedia.org/wiki/Nitrosourea "Wikipedia", http://en.wikipedia.org/wiki/Propyl "Wikipedia", pubchem.compound:13157]
 synonym: "1-nitroso-1-propylurea" EXACT []
 synonym: "1-propyl-1-nitrosourea" RELATED []
 synonym: "PNU" RELATED []
@@ -3089,7 +3088,7 @@ synonym: "ENU" RELATED []
 synonym: "ethylnitrosourea" EXACT []
 synonym: "N-ethyl-N-nitroso carbamide" EXACT []
 xref: CHEBI:23995
-xref: PubChem_Compound:CID_12967
+xref: pubchem.compound:12967
 is_a: XCO:0000205 ! mutation inducing chemical
 is_a: XCO:0000343 ! nitrosourea
 created_by: JSmith
@@ -3104,7 +3103,7 @@ synonym: "methylnitrosourea" EXACT []
 synonym: "MNU" RELATED []
 synonym: "N-methyl-N-nitrosocarbamide" EXACT []
 xref: CHEBI:50102
-xref: PubChem_Compound:CID_12967
+xref: pubchem.compound:12967
 is_a: XCO:0000089 ! neoplasm-inducing chemical
 is_a: XCO:0000205 ! mutation inducing chemical
 is_a: XCO:0000343 ! nitrosourea
@@ -3183,7 +3182,7 @@ def: "A guanidine derivative with a nitro group (-NO2) on the nitrogen at positi
 synonym: "1-methyl-3-nitro-1-nitrosoguanidine" EXACT []
 synonym: "methylnitronitrosoguanidine" EXACT []
 synonym: "MNNG" RELATED []
-synonym: "PubChem_Compound CID_9562060" RELATED []
+xref: pubchem.compound:9562060
 xref: CHEBI:21759
 is_a: XCO:0000089 ! neoplasm-inducing chemical
 is_a: XCO:0000205 ! mutation inducing chemical
@@ -3833,7 +3832,7 @@ synonym: "2-methyl-5-propan-2-ylcyclohexa-2,5-diene-1,4-dione" EXACT []
 synonym: "dihydrothymoquinone" EXACT []
 xref: CHEBI:113532
 xref: MESH:C003466
-xref: PubChem_Compound_CID:10281
+xref: pubchem.compound:10281
 is_a: XCO:0000271 ! antioxidant
 is_a: XCO:0000422 ! quinone
 created_by: JSmith
@@ -3957,7 +3956,7 @@ creation_date: 2014-03-12T13:30:22Z
 [Term]
 id: XCO:0000436
 name: controlled N-propyl-N-nitrosourea content diet
-def: "A solid diet in which the amount of N-propyl-N-nitrosourea (PNU) is maintained at a specified level. PNU is a mutation-inducing chemical with three major moieties, a propyl group (-C3H7), a nitroso group (R-N=O) and a urea group (two -NH2 groups joined by a carbonyl (C=O) functional group)." [http://en.wikipedia.org/wiki/Nitrosourea "Wikipedia", Mosby:Mosbys_Medical_Dictionary--8th_Ed, PubChem_Compound:CID_13157]
+def: "A solid diet in which the amount of N-propyl-N-nitrosourea (PNU) is maintained at a specified level. PNU is a mutation-inducing chemical with three major moieties, a propyl group (-C3H7), a nitroso group (R-N=O) and a urea group (two -NH2 groups joined by a carbonyl (C=O) functional group)." [http://en.wikipedia.org/wiki/Nitrosourea "Wikipedia", Mosby:Mosbys_Medical_Dictionary--8th_Ed, pubchem.compound:13157]
 synonym: "controlled 1-nitroso-1-propylurea content diet" EXACT []
 synonym: "controlled 1-propyl-1-nitrosourea content diet" RELATED []
 synonym: "controlled PNU content diet" RELATED []
@@ -3970,7 +3969,7 @@ creation_date: 2014-04-17T12:42:14Z
 [Term]
 id: XCO:0000437
 name: controlled N-propyl-N-nitrosourea content drinking water
-def: "A drink made up of water and a specified amount of N-propyl-N-nitrosourea (PNU) consumed by an organism as part of an experiment. PNU is a mutation-inducing chemical with three major moieties, a propyl group (-C3H7), a nitroso group (R-N=O) and a urea group (two -NH2 groups joined by a carbonyl (C=O) functional group)." [Dorland:Dorlands_Illustrated_Medical_Dictionary--31st_Ed, http://en.wikipedia.org/wiki/Nitrosourea "Wikipedia", ISBN:978-1416049982, PubChem_Compound:CID_13157]
+def: "A drink made up of water and a specified amount of N-propyl-N-nitrosourea (PNU) consumed by an organism as part of an experiment. PNU is a mutation-inducing chemical with three major moieties, a propyl group (-C3H7), a nitroso group (R-N=O) and a urea group (two -NH2 groups joined by a carbonyl (C=O) functional group)." [Dorland:Dorlands_Illustrated_Medical_Dictionary--31st_Ed, http://en.wikipedia.org/wiki/Nitrosourea "Wikipedia", ISBN:978-1416049982, pubchem.compound:13157]
 synonym: "controlled 1-nitroso-1-propylurea content drinking water" EXACT []
 synonym: "controlled 1-propyl-1-nitrosourea content drinking water" RELATED []
 synonym: "controlled PNU content drinking water" RELATED []
@@ -4369,7 +4368,7 @@ creation_date: 2015-04-29T14:14:39Z
 id: XCO:0000476
 name: Streptococcus pneumoniae
 def: "A condition in which the primary influencing factor is Streptococcus pneumoniae, a species of Gram-positive, alpha-hemolytic, facultative anaerobic bacteria commonly found in the nasopharynx of healthy human carriers." [http://en.wikipedia.org/wiki/Streptococcus_pneumoniae "Wikipedia"]
-xref: NCBI_Taxon:1313
+xref: NCBITaxon:1313
 is_a: XCO:0000475 ! bacterial pathogen
 created_by: JSmith
 creation_date: 2015-04-30T13:35:44Z
@@ -4379,7 +4378,7 @@ id: XCO:0000477
 name: Streptococcus pneumoniae D39
 def: "A condition in which the primary influencing factor is Streptococcus pneumoniae D39, a potentially virulent strain of the S. pneumoniae species of Gram-positive, alpha-hemolytic, facultative anaerobic bacteria commonly found in the nasopharynx of healthy human carriers." [http://en.wikipedia.org/wiki/Streptococcus_pneumoniae "Wikipedia"]
 synonym: "Streptococcus pneumoniae strain D39" EXACT []
-xref: NCBI_Taxon:373153
+xref: NCBITaxon:373153
 is_a: XCO:0000476 ! Streptococcus pneumoniae
 created_by: JSmith
 creation_date: 2015-04-30T13:36:39Z
@@ -4389,7 +4388,7 @@ id: XCO:0000478
 name: Streptococcus pneumoniae TIGR4
 def: "A condition in which the primary influencing factor is Streptococcus pneumoniae TIGR4, a potentially virulent strain of the S. pneumoniae species of Gram-positive, alpha-hemolytic, facultative anaerobic bacteria commonly found in the nasopharynx of healthy human carriers." [http://en.wikipedia.org/wiki/Streptococcus_pneumoniae "Wikipedia"]
 synonym: "Streptococcus pneumoniae strain TIGR4" EXACT []
-xref: NCBI_Taxon:170187
+xref: NCBITaxon:170187
 is_a: XCO:0000476 ! Streptococcus pneumoniae
 created_by: JSmith
 creation_date: 2015-04-30T13:38:57Z
@@ -4398,7 +4397,7 @@ creation_date: 2015-04-30T13:38:57Z
 id: XCO:0000479
 name: Haemophilus influenzae
 def: "A condition in which the primary influencing factor is Haemophilus influenzae, a Gram-negative, coccobacillary, facultatively anaerobic bacterium which is considered an opportunistic pathogen, i.e. one that can colonize a host without causing disease unless there are extenuating circumstances which result in susceptibility on the part of the host." [http://en.wikipedia.org/wiki/Haemophilus_influenzae "Wikipedia"]
-xref: NCBI_Taxon:727
+xref: NCBITaxon:727
 is_a: XCO:0000743 ! Haemophilus
 created_by: JSmith
 creation_date: 2015-04-30T13:41:32Z
@@ -4419,7 +4418,7 @@ def: "A condition in which the primary influencing factor is the 86-028NP strain
 synonym: "86028NP" RELATED []
 synonym: "Haemophilus influenzae strain 86-028NP" EXACT []
 synonym: "NTHi 86-028NP" RELATED []
-xref: NCBI_Taxon:281310
+xref: NCBITaxon:281310
 is_a: XCO:0000480 ! nontypeable Haemophilus influenzae
 created_by: JSmith
 creation_date: 2015-04-30T13:48:27Z
@@ -4459,7 +4458,7 @@ def: "A condition in which the primary influencing factor is the H2 mutant of th
 synonym: "86H2" RELATED []
 synonym: "Haemophilus influenzae mutant strain 86-028NP-H2" EXACT []
 synonym: "NTHi 86-028NP H2 mutant" RELATED []
-xref: NCBI_Taxon:281310
+xref: NCBITaxon:281310
 is_a: XCO:0000481 ! Haemophilus influenzae 86-028NP
 created_by: JSmith
 creation_date: 2015-05-14T17:54:23Z
@@ -4471,7 +4470,7 @@ def: "A condition in which the primary influencing factor is the C5 mutant of th
 synonym: "86C5" RELATED []
 synonym: "Haemophilus influenzae mutant strain 86-028NP-C5" EXACT []
 synonym: "NTHi 86-028NP C5 mutant" RELATED []
-xref: NCBI_Taxon:281310
+xref: NCBITaxon:281310
 is_a: XCO:0000481 ! Haemophilus influenzae 86-028NP
 created_by: JSmith
 creation_date: 2015-05-14T17:58:28Z
@@ -4482,7 +4481,7 @@ name: Streptococcus pneumoniae TIGR4 LuxS mutant
 def: "A condition in which the primary influencing factor is the LuxS mutant of Streptococcus pneumoniae TIGR4." [RGD:JRS]
 synonym: "Streptococcus pneumoniae mutant strain TIGR4luxS" EXACT []
 synonym: "TIGR4luxS" RELATED []
-xref: NCBI_Taxon:170187
+xref: NCBITaxon:170187
 is_a: XCO:0000478 ! Streptococcus pneumoniae TIGR4
 created_by: JSmith
 creation_date: 2015-05-14T17:59:26Z
@@ -4976,7 +4975,7 @@ creation_date: 2018-05-14T18:34:03Z
 [Term]
 id: XCO:0000539
 name: doxorubicin
-def: "An experimental condition in which the main influencing factor is doxorubicin, a cytotoxic anthracycline antibiotic isolated from cultures of Streptomyces peucetius var. caesius and used as a chemotherapy medication. Doxorubicin binds to nucleic acids, presumably by specific intercalation of the planar anthracycline nucleus with the DNA double helix." [https://en.wikipedia.org/wiki/Doxorubicin "Wikipedia", https://www.drugbank.ca/drugs/DB00997 "DrugBank"]
+def: "An experimental condition in which the main influencing factor is doxorubicin, a cytotoxic anthracycline antibiotic isolated from cultures of Streptomyces peucetius var. caesius and used as a chemotherapy medication. Doxorubicin binds to nucleic acids, presumably by specific intercalation of the planar anthracycline nucleus with the DNA double helix." [https://en.wikipedia.org/wiki/Doxorubicin "Wikipedia", drugbank:DB00997]
 synonym: "ADR" EXACT []
 synonym: "Adriablastine" EXACT []
 synonym: "adriamycin" EXACT []
@@ -5069,7 +5068,7 @@ creation_date: 2018-05-15T16:44:29Z
 [Term]
 id: XCO:0000548
 name: ramipril
-def: "An experimental condition in which the main influencing factor is ramipril, a prodrug that is metabolized in the liver to ramiprilat, a potent, competitive inhibitor of angiotensin-converting enzyme (ACE)." [https://www.drugbank.ca/drugs/DB00178 "DrugBank", MESH:D017257]
+def: "An experimental condition in which the main influencing factor is ramipril, a prodrug that is metabolized in the liver to ramiprilat, a potent, competitive inhibitor of angiotensin-converting enzyme (ACE)." [drugbank:DB00178, MESH:D017257]
 synonym: "Altace" EXACT []
 synonym: "Tritace" EXACT []
 xref: CHEBI:8774
@@ -5092,7 +5091,7 @@ creation_date: 2018-05-15T16:57:52Z
 [Term]
 id: XCO:0000550
 name: reserpine
-def: "An experimental condition in which the main influencing factor is reserpine, an indole alkaloid which irreversibly blocks the vesicular monoamine transporters (VMATs), SLC18A1 and SLC18A2. Reserpine has been used as both an antihypertensive drug and an antipsychotic drug." [https://en.wikipedia.org/wiki/Reserpine "Wikipedia", https://www.drugbank.ca/drugs/DB00206 "DrugBank", PMID:7905859]
+def: "An experimental condition in which the main influencing factor is reserpine, an indole alkaloid which irreversibly blocks the vesicular monoamine transporters (VMATs), SLC18A1 and SLC18A2. Reserpine has been used as both an antihypertensive drug and an antipsychotic drug." [https://en.wikipedia.org/wiki/Reserpine "Wikipedia", drugbank:DB00206, PMID:7905859]
 synonym: "methyl (3beta,16beta,17alpha,18beta,20alpha)-11,17-dimethoxy-18-[(3,4,5-trimethoxybenzoyl)oxy]yohimban-16-carboxylate" EXACT []
 synonym: "Serpasil" EXACT []
 xref: CHEBI:28487
@@ -5105,7 +5104,7 @@ creation_date: 2018-05-15T17:19:06Z
 [Term]
 id: XCO:0000551
 name: hydralazine
-def: "An experimental condition in which the main influencing factor is hydralazine, a vasodilator that appears to have multiple, direct effects on smooth muscles of the arterial vessels, thereby reducing systemic vascular resistance and arterial pressure." [http://cvpharmacology.com/vasodilator/direct "Website", https://www.drugbank.ca/drugs/DB01275 "DrugBank"]
+def: "An experimental condition in which the main influencing factor is hydralazine, a vasodilator that appears to have multiple, direct effects on smooth muscles of the arterial vessels, thereby reducing systemic vascular resistance and arterial pressure." [http://cvpharmacology.com/vasodilator/direct "Website", drugbank:DB01275]
 is_a: XCO:0000140 ! vasodilator
 created_by: jrsmith
 creation_date: 2018-05-15T17:22:47Z
@@ -5113,7 +5112,7 @@ creation_date: 2018-05-15T17:22:47Z
 [Term]
 id: XCO:0000552
 name: controlled hydralazine content drinking water
-def: "This is an experimental condition in which the main influencing factor is a drink made up of water and a specified amount of hydralazine in which the amount of hydralazine consumed is maintained at a specified level." [https://www.merriam-webster.com/ "DrugBank", MESH:D006830]
+def: "This is an experimental condition in which the main influencing factor is a drink made up of water and a specified amount of hydralazine in which the amount of hydralazine consumed is maintained at a specified level." [https://www.merriam-webster.com/, MESH:D006830]
 xref: CHEBI:5775
 xref: PMID:3611778
 is_a: XCO:0000163 ! controlled content drinking water
@@ -5152,7 +5151,7 @@ creation_date: 2018-11-14T16:04:27Z
 id: XCO:0000556
 name: amino monosaccharide
 def: "Any amino sugar that is a monosaccharide in which one alcoholic hydroxy group is replaced by an amino group." []
-synonym: "CHEBI:60926" EXACT []
+xref: CHEBI:60926
 is_a: XCO:0000274 ! monosaccharide
 created_by: sjwang
 creation_date: 2018-11-16T10:50:55Z
@@ -5160,7 +5159,7 @@ creation_date: 2018-11-16T10:50:55Z
 [Term]
 id: XCO:0000557
 name: glucosamine
-def: "Glucosamine, commonly used as a treatment for osteoarthritis, is an amino sugar and a prominent precursor in the biochemical synthesis of glycosylated proteins and lipids. Since glucosamine is a precursor for glycosaminoglycans, and glycosaminoglycans are a major component of joint cartilage, supplemental glucosamine may help to rebuild cartilage and treat arthritis." [https://www.drugbank.ca/drugs/DB01296 "Drugbank"]
+def: "Glucosamine, commonly used as a treatment for osteoarthritis, is an amino sugar and a prominent precursor in the biochemical synthesis of glycosylated proteins and lipids. Since glucosamine is a precursor for glycosaminoglycans, and glycosaminoglycans are a major component of joint cartilage, supplemental glucosamine may help to rebuild cartilage and treat arthritis." [drugbank:DB01296]
 synonym: "2-amino-2-deoxyglucose" EXACT []
 is_a: XCO:0000556 ! amino monosaccharide
 created_by: sjwang
@@ -5171,8 +5170,8 @@ id: XCO:0000558
 name: taxifolin
 def: "Taxifolin is a flavanonol and a non-steroidal anti-inflammatory agent." [https://en.wikipedia.org/wiki/Taxifolin]
 synonym: "catechin hydrate" EXACT []
-synonym: "CHEBI:38747" EXACT []
 synonym: "DHQ" EXACT []
+xref: CHEBI:38747
 synonym: "dihydroquercetin" EXACT []
 synonym: "Distylin" EXACT []
 synonym: "Taxifoliol" EXACT []
@@ -5185,7 +5184,7 @@ creation_date: 2018-11-16T11:03:16Z
 id: XCO:0000559
 name: melatonin
 def: "A biogenic amine that is found in animals and plants. In mammals, melatonin is a hormone produced by the pineal gland. Its secretion increases in darkness and decreases during exposure to light. Melatonin is implicated in the regulation of sleep, mood, and reproduction. Melatonin is also an effective antioxidant." [https://druginfo.nlm.nih.gov/drugportal/name/melatonin "Drug Information Portal", https://meshb.nlm.nih.gov/record/ui?ui=D008550 "MESH"]
-synonym: "CHEBI:16796" EXACT []
+xref: CHEBI:16796
 is_a: XCO:0000125 ! hormone
 is_a: XCO:0000271 ! antioxidant
 created_by: sjwang
@@ -5298,7 +5297,7 @@ creation_date: 2018-12-05T14:27:59Z
 id: XCO:0000572
 name: vancomycin
 def: "A complex glycopeptide from Streptomyces orientalis. It inhibits a specific step in the synthesis of the peptidoglycan layer in the Gram-positive bacteria Staphylococcus aureus and Clostridium difficile." []
-synonym: "CHEBI:28001" EXACT []
+xref: CHEBI:28001
 is_a: XCO:0000483 ! antibacterial agent
 created_by: sjwang
 creation_date: 2018-12-05T14:37:41Z
@@ -5442,9 +5441,9 @@ creation_date: 2018-12-06T16:45:37Z
 [Term]
 id: XCO:0000588
 name: perindopril
-def: "Perindopril is a nonsulfhydryl prodrug that belongs to the angiotensin-converting enzyme (ACE) inhibitor class of medications. It is rapidly metabolized in the liver to perindoprilat, a potent, competitive inhibitor of ACE." [https://www.drugbank.ca/drugs/DB00790 "Drugbank"]
+def: "Perindopril is a nonsulfhydryl prodrug that belongs to the angiotensin-converting enzyme (ACE) inhibitor class of medications. It is rapidly metabolized in the liver to perindoprilat, a potent, competitive inhibitor of ACE." [drugbank:DB00790]
 synonym: "Aceon" EXACT []
-synonym: "CHEBI:8024" EXACT []
+xref: CHEBI:8024
 synonym: "Coversum" EXACT []
 synonym: "Coversyl" EXACT []
 synonym: "ethyl N-{(2S)-1-[(2S,3aS,7aS)-2-carboxyoctahydro-1H-indol-1-yl]-1-oxopropan-2-yl}-L-norvalinate" EXACT []
@@ -5502,7 +5501,7 @@ creation_date: 2018-12-27T10:28:04Z
 id: XCO:0000594
 name: saralasin
 def: "A condition in which the main influencing factor is saralasin, a partial angiotensin II receptor agonist and antihypertensive agent." []
-synonym: "CHEBI:135894" EXACT []
+xref: CHEBI:135894
 synonym: "Sar-Arg-Val-Tyr-Val-His-Pro-Ala" EXACT []
 is_a: XCO:0000536 ! angiotensin II receptor antagonist
 is_a: XCO:0000863 ! antihypertensive agent
@@ -5557,7 +5556,7 @@ creation_date: 2018-12-27T15:39:58Z
 id: XCO:0000600
 name: 2,3,7,8-tetrachlorodibenzo-p-dioxin (TCDD)
 def: "A polychlorinated dibenzodioxine that has formula C12H4Cl4O2." []
-synonym: "CHEBI:28119" EXACT []
+xref: CHEBI:28119
 is_a: XCO:0000135 ! receptor agonist
 created_by: sjwang
 creation_date: 2019-01-21T12:54:07Z
@@ -5577,7 +5576,7 @@ creation_date: 2019-01-22T13:43:52Z
 id: XCO:0000602
 name: rosiglitazone
 def: "A peroxisome proliferator-activated receptor gamma agonist; reduces lipid availability, improves insulin action & glucoregulation" [https://druginfo.nlm.nih.gov/drugportal/name/rosiglitazone "Drug Information Portal"]
-synonym: "CHEBI:50122" EXACT []
+xref: CHEBI:50122
 is_a: XCO:0000135 ! receptor agonist
 is_a: XCO:0000407 ! hypoglycemic agent
 created_by: sjwang
@@ -5586,7 +5585,7 @@ creation_date: 2019-01-22T13:55:58Z
 [Term]
 id: XCO:0000603
 name: hesperetin
-def: "Hesperetin belongs to the flavanone class of flavonoids. Hesperetin, in the form of its glycoside Hesperidin, is the predominant flavonoid in lemons and oranges." [https://www.drugbank.ca/drugs/DB01094 "Drugbank"]
+def: "Hesperetin belongs to the flavanone class of flavonoids. Hesperetin, in the form of its glycoside Hesperidin, is the predominant flavonoid in lemons and oranges." [drugbank:DB01094]
 xref: CHEBI:28230
 xref: MESH:C013015
 is_a: XCO:0000470 ! flavonoid
@@ -5596,7 +5595,7 @@ creation_date: 2019-01-22T14:38:41Z
 [Term]
 id: XCO:0000604
 name: Aprotinin
-def: "Any condition in which the main influencing factor is Aprotinin, also known as bovine pancreatic trypsin inhibitor (BPTI), a proteinase inhibitor used as medication administered by injection to reduce bleeding during complex surgery, such as heart and liver surgery." [https://www.drugbank.ca/drugs/DB06692 "Drugbank"]
+def: "Any condition in which the main influencing factor is Aprotinin, also known as bovine pancreatic trypsin inhibitor (BPTI), a proteinase inhibitor used as medication administered by injection to reduce bleeding during complex surgery, such as heart and liver surgery." [drugbank:DB06692]
 synonym: "C284H432N84O79S7" EXACT []
 synonym: "Trasylol" EXACT []
 is_a: XCO:0000748 ! protease inhibitor
@@ -5631,7 +5630,7 @@ creation_date: 2019-03-19T17:06:26Z
 id: XCO:0000608
 name: Allyl isothiocyanate
 alt_id: CHEBI:73224
-alt_id: Pubchem:5971
+alt_id: pubchem.compound:5971
 def: "An isothiocyanate with the formula CH2=CHCH2N=C=S. A colorless oil with boiling point 152degreeC, it is responsible for the pungent taste of mustard, horseradish, and wasabi." [CHEBI:73224]
 synonym: "mustard oil" RELATED []
 is_a: XCO:0000435 ! antineoplastic agent
@@ -5644,7 +5643,7 @@ id: XCO:0000609
 name: 4-methyl-2-(piperidin-1-yl) quinoline
 def: "A potent and selective blocker of TRPC4 channels." [PMID:24388923]
 synonym: "ML-204" EXACT []
-synonym: "Pubchem:230710" EXACT []
+xref: pubchem.compound:230710
 is_a: XCO:0000222 ! cation channel inhibitor
 created_by: sjwang
 creation_date: 2019-03-27T15:43:10Z
@@ -5653,8 +5652,8 @@ creation_date: 2019-03-27T15:43:10Z
 id: XCO:0000610
 name: morphine
 def: "A morphinane alkaloid that is a highly potent opiate analgesic psychoactive drug. Morphine acts directly on the central nervous system (CNS) to relieve pain but has a high potential for addiction, with tolerance and both physical and psychological dependence developing rapidly. Morphine is the most abundant opiate found in Papaver somniferum (the opium poppy)." [CHEBI:17303]
-synonym: "CHEBI:17303" EXACT []
-synonym: "Pubchem: 5288826" EXACT []
+xref: CHEBI:17303
+xref: pubchem.compound:5288826
 is_a: XCO:0000106 ! anesthetic/analgesic
 created_by: sjwang
 creation_date: 2019-03-27T15:52:55Z
@@ -5662,8 +5661,8 @@ creation_date: 2019-03-27T15:52:55Z
 [Term]
 id: XCO:0000611
 name: nifedipine
-def: "Nifedipine is a potent vasodilator agent with calcium antagonistic action. It is a useful anti-anginal agent that also lowers blood pressure." [https://meshb.nlm.nih.gov/record/ui?ui=D009543 "MESH"]
-synonym: "Pubchem: 4485" EXACT []
+def: "Nifedipine is a potent vasodilator agent with calcium antagonistic action. It is a useful anti-anginal agent that also lowers blood pressure." [MESH:D009543]
+xref: pubchem.compound:4485
 is_a: XCO:0000269 ! calcium channel inhibitor
 xref: CHEBI:7565
 created_by: sjwang
@@ -5673,8 +5672,8 @@ creation_date: 2019-04-22T16:41:50Z
 id: XCO:0000612
 name: Endothelin-1
 def: "Endothelin-1 is a 21-amino acid peptide produced in a variety of tissues including endothelial and vascular smooth-muscle cells, neurons and astrocytes in the central nervous system, and endometrial cells. It acts as a modulator of vasomotor tone, cell proliferation, and hormone production." [PMID:7609754]
-synonym: "CHEBI:80240 Endothelin-1" EXACT []
-synonym: "Pubchem: 16212950" EXACT []
+xref: CHEBI:80240
+xref: pubchem.compound:16212950
 is_a: XCO:0000193 ! peptide/protein
 created_by: sjwang
 creation_date: 2019-05-08T14:50:29Z
@@ -5683,8 +5682,8 @@ creation_date: 2019-05-08T14:50:29Z
 id: XCO:0000613
 name: Adenosine triphosphate
 def: "Adenosine Triphosphate (ATP) is an adenine nucleotide comprised of three phosphate groups esterified to the sugar moiety, found in all living cells. Adenosine triphosphate is involved in energy production for metabolic processes and RNA synthesis. In addition, this substance acts as a neurotransmitter. In cancer studies, adenosine triphosphate is synthesized to examine its use to decrease weight loss and improve muscle strength." [https://ncit.nci.nih.gov/ncitbrowser/ "NIH Thesaurus"]
-synonym: "CHEBI:15422" EXACT []
-synonym: "Pubchem: 5957" EXACT []
+xref: CHEBI:15422
+xref: pubchem.compound:5957
 is_a: XCO:0000392 ! nucleoside/nucleotide
 created_by: sjwang
 creation_date: 2019-05-08T15:10:50Z
@@ -5693,7 +5692,7 @@ creation_date: 2019-05-08T15:10:50Z
 id: XCO:0000614
 name: rolipram
 def: "A phosphodiesterase 4 inhibitor with antidepressant properties." [https://www.ncbi.nlm.nih.gov/mesh/68020889 "MESH"]
-synonym: "CHEBI:104872" EXACT []
+xref: CHEBI:104872
 is_a: XCO:0000523 ! enzyme inhibitor
 created_by: sjwang
 creation_date: 2019-05-22T13:50:17Z
@@ -5710,8 +5709,8 @@ creation_date: 2019-05-22T14:06:17Z
 id: XCO:0000616
 name: verapamil
 def: "Verapamil is a calcium channel blocker that is a class IV anti-arrhythmia agent." [https://www.ncbi.nlm.nih.gov/mesh?Db=mesh&Cmd=DetailsSearch&Term=%22Verapamil%22%5BMeSH+Terms%5D "MESH"]
-synonym: "CHEBI:9948" EXACT []
-synonym: "Pubchem: 2520" EXACT []
+xref: CHEBI:9948
+xref: pubchem.compound:2520
 is_a: XCO:0000269 ! calcium channel inhibitor
 created_by: sjwang
 creation_date: 2019-05-23T14:15:07Z
@@ -5719,9 +5718,9 @@ creation_date: 2019-05-23T14:15:07Z
 [Term]
 id: XCO:0000617
 name: quinidine
-def: "Quinidine sulfate is an optical isomer of quinine, extracted from the bark of the CHINCHONA tree and similar plant species. This alkaloid dampens the excitability of cardiac and skeletal muscles by blocking sodium and potassium currents across cellular membranes. It prolongs cellular ACTION POTENTIALS, and decreases automaticity. Quinidine also blocks muscarinic and alpha-adrenergic neurotransmission." [https://www.ncbi.nlm.nih.gov/mesh/68011802 "MESH"]
-synonym: "CHEBI:28593" EXACT []
-synonym: "Pubchem: 5953" EXACT []
+def: "Quinidine sulfate is an optical isomer of quinine, extracted from the bark of the CHINCHONA tree and similar plant species. This alkaloid dampens the excitability of cardiac and skeletal muscles by blocking sodium and potassium currents across cellular membranes. It prolongs cellular ACTION POTENTIALS, and decreases automaticity. Quinidine also blocks muscarinic and alpha-adrenergic neurotransmission." [MESH:68011802]
+xref: CHEBI:28593
+xref: pubchem.compound:5953
 is_a: XCO:0000618 ! sodium channel inhibitor
 created_by: sjwang
 creation_date: 2019-05-23T14:24:09Z
@@ -5729,7 +5728,7 @@ creation_date: 2019-05-23T14:24:09Z
 [Term]
 id: XCO:0000618
 name: sodium channel inhibitor
-def: "A class of drugs that act by inhibition of sodium influx through cell membranes. Blockade of sodium channels slows the rate and amplitude of initial rapid depolarization, reduces cell excitability, and reduces conduction velocity." [https://www.drugbank.ca/categories/DBCAT000600 "Drugbank"]
+def: "A class of drugs that act by inhibition of sodium influx through cell membranes. Blockade of sodium channels slows the rate and amplitude of initial rapid depolarization, reduces cell excitability, and reduces conduction velocity." [drugbank.category:DBCAT000600]
 synonym: "Sodium Channel Blockers" EXACT []
 is_a: XCO:0000222 ! cation channel inhibitor
 created_by: sjwang
@@ -5739,8 +5738,8 @@ creation_date: 2019-05-23T14:37:49Z
 id: XCO:0000619
 name: digoxin
 def: "A cardenolide glycoside that is digitoxin &#946;-hydroxylated at C-12. A cardiac glycoside extracted from the foxglove plant, Digitalis lanata, it is used to control ventricular rate in atrial fibrillation and in the management of congestive heart failure with atrial fibrillation, but the margin between toxic and therapeutic doses is small." []
-synonym: "CHEBI:4551" EXACT []
-synonym: "Pubchem:2724385" EXACT []
+xref: CHEBI:4551
+xref: pubchem.compound:2724385
 is_a: XCO:0000139 ! vasoactive chemical
 created_by: sjwang
 creation_date: 2019-05-23T14:45:00Z
@@ -5749,8 +5748,8 @@ creation_date: 2019-05-23T14:45:00Z
 id: XCO:0000620
 name: vinblastine
 def: "Vinblastine is a natural alkaloid isolated from the plant Vinca rosea Linn. Vinblastine binds to tubulin and inhibits microtubule formation, resulting in disruption of mitotic spindle assembly and arrest of tumor cells in the M phase of the cell cycle. This agent may also interfere with amino acid, cyclic AMP, and glutathione metabolism; calmodulin-dependent Ca++ -transport ATPase activity; cellular respiration; and nucleic acid and lipid biosynthesis." [https://ncit-stage.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=C930&ns=ncit "NCI Thesaurus"]
-synonym: "CHEBI:1322" EXACT []
-synonym: "Pubchem: 13342" EXACT []
+xref: CHEBI:1322
+xref: pubchem.compound:13342
 is_a: XCO:0000435 ! antineoplastic agent
 created_by: sjwang
 creation_date: 2019-05-23T15:08:50Z
@@ -5798,7 +5797,7 @@ creation_date: 2019-07-17T10:08:35Z
 id: XCO:0000625
 name: urethane
 def: "Antineoplastic agent that is also used as a veterinary anesthetic." []
-synonym: "CHEBI:17967" EXACT []
+xref: CHEBI:17967
 synonym: "MESH:D014520" EXACT []
 is_a: XCO:0000106 ! anesthetic/analgesic
 is_a: XCO:0000435 ! antineoplastic agent
@@ -5816,8 +5815,8 @@ creation_date: 2019-07-17T10:22:31Z
 [Term]
 id: XCO:0000627
 name: spironolactone
-def: "Any condition in which the main influencing factor isspironolactone, a potassium-sparing diuretic that competitively inhibits mineralocorticoid receptors in the distal convoluted tubule to promote sodium and water excretion and potassium retention. Spironolactone is indicated to treat a number of conditions including heart failure, edema, hyperaldosteronism, adrenal hyperplasia, hypertension, and nephrotic syndrome." [https://www.drugbank.ca/drugs/DB00421 "DRUGBANK"]
-synonym: "CHEBI:9241" EXACT []
+def: "Any condition in which the main influencing factor isspironolactone, a potassium-sparing diuretic that competitively inhibits mineralocorticoid receptors in the distal convoluted tubule to promote sodium and water excretion and potassium retention. Spironolactone is indicated to treat a number of conditions including heart failure, edema, hyperaldosteronism, adrenal hyperplasia, hypertension, and nephrotic syndrome." [drugbank:DB00421]
+xref: CHEBI:9241
 synonym: "DB00421" EXACT []
 is_a: XCO:0000122 ! diuretic
 is_a: XCO:0000838 ! mineralocorticoid receptor antagonist
@@ -5828,7 +5827,7 @@ creation_date: 2019-07-24T14:33:14Z
 id: XCO:0000628
 name: Atorvastatin
 def: "Atorvastatin (Lipitor) is a member of the drug class known as statins. It is used for lowering cholesterol. Atorvastatin is a competitive inhibitor of hydroxymethylglutaryl-coenzyme A (HMG-CoA) reductase, the rate-determining enzyme in cholesterol biosynthesis via the mevalonate pathway. HMG-CoA reductase catalyzes the conversion of HMG-CoA to mevalonate. Atorvastatin acts primarily in the liver. Decreased hepatic cholesterol levels increases hepatic uptake of cholesterol and reduces plasma cholesterol levels." []
-synonym: "CHEBI:39548" EXACT []
+xref: CHEBI:39548
 synonym: "Lipitor" RELATED []
 is_a: XCO:0000523 ! enzyme inhibitor
 created_by: sjwang
@@ -5839,7 +5838,7 @@ id: XCO:0000629
 name: carbenoxolone
 def: "An agent derived from licorice root. It is used for the treatment of digestive tract ulcers, especially in the stomach. Antidiuretic side effects are frequent, but otherwise the drug is low in toxicity." []
 synonym: "MESH:D002229" EXACT []
-synonym: "pubchem: 636403" EXACT []
+xref: pubchem.compound:636403
 is_a: XCO:0000279 ! terpene
 created_by: sjwang
 creation_date: 2019-07-24T16:11:51Z
@@ -5855,8 +5854,8 @@ creation_date: 2019-07-30T14:47:58Z
 [Term]
 id: XCO:0000631
 name: atropine
-def: "A naturally occurring belladonna alkaloid, is a racemic mixture of equal parts of d- and l-hyoscyamine, whose activity is due almost entirely to the levo isomer of the drug. Atropine is commonly classified as an anticholinergic or antiparasympathetic (parasympatholytic) drug. More precisely, however, it is termed an antimuscarinic agent since it antagonizes the muscarine-like actions of acetylcholine and other choline esters." [https://www.drugbank.ca/drugs/DB00572 "DRUGBANK"]
-synonym: "CHEBI:16684" EXACT []
+def: "A naturally occurring belladonna alkaloid, is a racemic mixture of equal parts of d- and l-hyoscyamine, whose activity is due almost entirely to the levo isomer of the drug. Atropine is commonly classified as an anticholinergic or antiparasympathetic (parasympatholytic) drug. More precisely, however, it is termed an antimuscarinic agent since it antagonizes the muscarine-like actions of acetylcholine and other choline esters." [drugbank:DB00572]
+xref: CHEBI:16684
 is_a: XCO:0000630 ! cholinergic antagonist
 created_by: sjwang
 creation_date: 2019-07-30T14:53:02Z
@@ -5907,7 +5906,7 @@ creation_date: 2019-07-30T16:18:43Z
 id: XCO:0000636
 name: immunosuppressive agent
 def: "An agent that suppresses immune function by one of several mechanisms of action. Classical cytotoxic immunosuppressants act by inhibiting DNA synthesis. Others may act through activation of T-cells or by inhibiting the activation of helper cells. In addition, an immunosuppressive agent is a role played by a compound which is exhibited by a capability to diminish the extent and/or voracity of an immune response." [CHEBI:35705]
-synonym: "CHEBI:35705" EXACT []
+xref: CHEBI:35705
 is_a: XCO:0000341 ! chemical with specified function
 created_by: sjwang
 creation_date: 2019-08-01T12:47:37Z
@@ -5916,7 +5915,7 @@ creation_date: 2019-08-01T12:47:37Z
 id: XCO:0000637
 name: cyclosporine A
 def: "A cyclic nonribosomal peptide of eleven amino acids; an immunosuppressant drug widely used in post-allogeneic organ transplant to reduce the activity of the patient's immune system, and therefore the risk of organ rejection. Also causes reversible inhibition of immunocompetent lymphocytes in the G0- and G1-phase of the cell cycle." [CHEBI:4031]
-synonym: "CHEBI:4031" EXACT []
+xref: CHEBI:4031
 synonym: "cyclosporine" RELATED []
 is_a: XCO:0000636 ! immunosuppressive agent
 created_by: sjwang
@@ -5926,7 +5925,7 @@ creation_date: 2019-08-01T12:50:36Z
 id: XCO:0000638
 name: Capsazepine
 def: "A benzazepine that is 2,3,4,5-tetrahydro-1H-2-benzazepine which is substituted by hydroxy groups at positions 7 and 8 and on the nitrogen atom by a 2-(p-chlorophenyl)ethylaminothiocarbonyl group. A synthetic analogue of capsaicin, it was the first reported capsaicin receptor antagonist." [CHEBI:70773]
-synonym: "CHEBI:70773" EXACT []
+xref: CHEBI:70773
 is_a: XCO:0000160 ! receptor antagonist
 created_by: sjwang
 creation_date: 2019-08-01T12:59:35Z
@@ -5959,10 +5958,10 @@ creation_date: 2019-08-01T14:50:02Z
 id: XCO:0000642
 name: monocrotaline
 def: "Monocrotaline is a pyrrolizidine alkaloid and a toxic plant constituent that poisons livestock and humans through the ingestion of contaminated grains and other foods. The alkaloid causes pulmonary artery hypertension, right ventricular hypertrophy, and pathological changes in the pulmonary vasculature. Significant attenuation of the cardiopulmonary changes are noted after oral magnesium treatment." [https://www.ncbi.nlm.nih.gov/mesh/68016686 "MESH"]
-synonym: "CHEBI:6980" EXACT []
+xref: CHEBI:6980
 synonym: "https://www.ncbi.nlm.nih.gov/mesh/68016686" RELATED []
 synonym: "MCT" RELATED []
-synonym: "Pubchem: 9415" EXACT []
+xref: pubchem.compound:9415
 is_a: XCO:0000239 ! toxic substance
 created_by: sjwang
 creation_date: 2019-08-01T17:00:38Z
@@ -5987,7 +5986,7 @@ creation_date: 2019-11-05T10:21:40Z
 id: XCO:0000645
 name: propofol
 def: "A phenol resulting from the formal substitution of the hydrogen at the 2 position of 1,3-diisopropylbenzene by a hydroxy group." []
-synonym: "CHEBI:44915" EXACT []
+xref: CHEBI:44915
 is_a: XCO:0000106 ! anesthetic/analgesic
 created_by: sjwang
 creation_date: 2019-11-27T12:37:25Z
@@ -5996,9 +5995,9 @@ creation_date: 2019-11-27T12:37:25Z
 id: XCO:0000646
 name: Azoxymethane
 def: "Azoxymethane (AOM), a gene mutation agent, may be used with dextran sulfate sodium (DSS) to create cancer models in laboratory animals which can be used to study mechanisms of cancer progression and chemoprevention." []
-synonym: "CAS:25843-45-2" EXACT []
+xref: CAS:25843-45-2
 synonym: "ML-MFCD00126912" EXACT []
-synonym: "Pubchem:329770827" EXACT []
+xref: pubchem.compound:329770827
 is_a: XCO:0000089 ! neoplasm-inducing chemical
 created_by: sjwang
 creation_date: 2019-12-04T15:04:39Z
@@ -6006,7 +6005,7 @@ creation_date: 2019-12-04T15:04:39Z
 [Term]
 id: XCO:0000647
 name: darusentan
-def: "A selective endothelin ETA receptor antagonist. It is being evaluated as a treatment for congestive heart failure and hypertension." [https://www.drugbank.ca/drugs/DB04883 "drugbank"]
+def: "A selective endothelin ETA receptor antagonist. It is being evaluated as a treatment for congestive heart failure and hypertension." [drugbank:DB04883]
 is_a: XCO:0000730 ! endothelin receptor antagonist
 created_by: slaulede
 creation_date: 2019-12-09T18:27:43Z
@@ -6025,7 +6024,7 @@ creation_date: 2019-12-10T17:07:59Z
 id: XCO:0000649
 name: trans-4-hydroxy-L-proline
 def: "An optically active form of 4-hydroxyproline having L-trans-configuration." []
-synonym: "CHEBI:18095" EXACT []
+xref: CHEBI:18095
 is_a: XCO:0000259 ! disease-inducing chemical
 created_by: sjwang
 creation_date: 2019-12-12T13:16:31Z
@@ -6353,7 +6352,7 @@ id: XCO:0000681
 name: Medica 16
 def: "An &#945;,&#969;-dicarboxylic acid that is hexadecanedioic acid carrying methyl groups at positions 3 and 14. It is a free fatty acid 1 (FFA1/GPR40) receptor agonist and an ATP citrate lyase inhibitor, and exhibits hypolipidemic and antidiabetogenic properties." [CHEBI:149582]
 synonym: "3,3,14,14-Tetramethylhexadecanedioic acid" EXACT []
-synonym: "CAS 87272-20-6" EXACT []
+xref: CAS:87272-20-6
 synonym: "Medic-16" EXACT []
 xref: CHEBI:149582
 is_a: XCO:0000135 ! receptor agonist
@@ -6910,7 +6909,7 @@ creation_date: 2020-07-27T15:38:14Z
 id: XCO:0000730
 name: endothelin receptor antagonist
 def: "Any condition in which the main influencing factor is an agent that blocks one or more endothelin receptors." [XCO:0000536]
-synonym: "CHEBI:51451" EXACT []
+xref: CHEBI:51451
 synonym: "endothelin receptor blocker" EXACT []
 is_a: XCO:0000160 ! receptor antagonist
 created_by: slaulede
@@ -7541,7 +7540,7 @@ id: XCO:0000796
 name: U46619
 def: "A prostaglandin endoperoxide analogue (11,9 epoxymethano-prostaglandin H2) that is a selective agonist of prostaglandin H2 (PGH2)/thromboxane A2 (TxA2) (TP) receptor. It is a stable thromboxane A2 mimetic and a vasoconstrictor." [http://www.apexbt.com, https://www.sigmaaldrich.com]
 synonym: "9,11-Dideoxy-9&#945;,11&#945;-methanoepoxyprostaglandin F 2&#945;" EXACT []
-synonym: "CAS:56985-40-1" EXACT []
+xref: CAS:56985-40-1
 synonym: "U 46619" EXACT []
 xref: PMID:22508433
 is_a: XCO:0000135 ! receptor agonist
@@ -7552,7 +7551,7 @@ creation_date: 2021-01-04T16:46:45Z
 id: XCO:0000797
 name: Y-27632
 def: "A monocarboxylic acid amide that is trans-[(1R)-1-aminoethyl]cyclohexanecarboxamide in which one of the nitrogens of the aminocarbony group is substituted by a pyridine nucleus. It is a cell-permeable, reversible inhibitor of Rho-associated protein kinase (ROCK) enzyme." [CHEBI:75393, https://www.sigmaaldrich.com]
-synonym: "CAS-146986-50-7" EXACT []
+xref: CAS:146986-50-7
 synonym: "Rho-associated protein kinase Inhibitor" EXACT []
 synonym: "ROCK Inhibitor" EXACT []
 synonym: "Y 27632" EXACT []
@@ -7616,7 +7615,7 @@ def: "It is a tertiary carboxamide and cell-permeable, potent and selective agon
 synonym: "C28H32Cl2N4O6S2" EXACT []
 xref: CAS:942206-85-1
 xref: PMID:29875065
-xref: Pubchem_CID:23630211
+xref: pubchem.compound:23630211
 is_a: XCO:0000217 ! cation channel activator
 created_by: slaulede
 creation_date: 2021-02-09T15:22:33Z
@@ -8230,9 +8229,9 @@ creation_date: 2021-06-29T18:22:55Z
 [Term]
 id: XCO:0000857
 name: vildagliptin
-def: "Any condition in which the main influencing factor is vildagliptin, a pyrrolidine-carbonitrile derivative and potent inhibitor of dipeptidyl peptidase 4 (DPP-4) that is used in the treatment of type 2 diabetes mellitus." [MESH:D000077597, PMID: 23774700]
+def: "Any condition in which the main influencing factor is vildagliptin, a pyrrolidine-carbonitrile derivative and potent inhibitor of dipeptidyl peptidase 4 (DPP-4) that is used in the treatment of type 2 diabetes mellitus." [MESH:D000077597, PMID:23774700]
 synonym: "VG" EXACT []
-xref: PMID: 23774700
+xref: PMID:23774700
 is_a: XCO:0000407 ! hypoglycemic agent
 created_by: slaulede
 creation_date: 2021-07-02T13:08:02Z
@@ -8516,7 +8515,7 @@ synonym: "4-iodo-5-methyl-1-(114C)methyl-2-phenylpyrazol-3-one" EXACT []
 synonym: "4-Iodoantipyrene-N-methyl-14C" EXACT []
 synonym: "C11H11IN2O" EXACT []
 xref: PMID:29498562
-xref: PubChem CID:101126542
+xref: pubchem.compound:101126542
 is_a: XCO:0000171 ! radioactively labeled chemical
 created_by: slaulede
 creation_date: 2021-07-29T17:59:13Z
@@ -8640,7 +8639,7 @@ creation_date: 2021-08-10T13:54:49Z
 [Term]
 id: XCO:0000892
 name: tumor promoter
-def: "Tumor promoters are substances that enhance tumorigenicity when administered after a carcinogen. In general, tumor promoters do not possess tumorigenic activity themselves." [https://www.cancer.gov/publications/dictionaries/cancer-terms/def/tumor-promotion, PMID: 10417370]
+def: "Tumor promoters are substances that enhance tumorigenicity when administered after a carcinogen. In general, tumor promoters do not possess tumorigenic activity themselves." [https://www.cancer.gov/publications/dictionaries/cancer-terms/def/tumor-promotion, PMID:10417370]
 xref: PMID:32300198
 is_a: XCO:0000259 ! disease-inducing chemical
 created_by: slaulede
@@ -8687,7 +8686,7 @@ creation_date: 2021-08-27T15:46:09Z
 [Term]
 id: XCO:0000896
 name: controlled hesperetin content diet
-def: "A regimen of solid food in which the amount of hesperetin is controlled. Hesperetin belongs to the flavanone class of flavonoids. Hesperetin, in the form of its glycoside Hesperidin, is the predominant flavonoid in lemons and oranges." [https://www.drugbank.ca/drugs/DB01094]
+def: "A regimen of solid food in which the amount of hesperetin is controlled. Hesperetin belongs to the flavanone class of flavonoids. Hesperetin, in the form of its glycoside Hesperidin, is the predominant flavonoid in lemons and oranges." [drugbank:DB01094]
 xref: CHEBI:28230
 xref: MESH:C013015
 is_a: XCO:0000014 ! controlled content diet
@@ -8867,7 +8866,7 @@ synonym: "controlled androstenolone content diet" EXACT []
 synonym: "controlled DHEA content diet" EXACT []
 xref: CHEBI:28689
 xref: MESH:D003687
-xref: PMID: 9415976
+xref: PMID:9415976
 is_a: XCO:0000014 ! controlled content diet
 is_a: XCO:0000865 ! dehydroepiandrosterone
 created_by: slaulede
@@ -8902,7 +8901,7 @@ def: "Any condition in which the main influencing factor is ethosuximide, a dica
 synonym: "3-ethyl-3-methylpyrrolidine-2,5-dione" EXACT []
 synonym: "Zarontin" EXACT []
 xref: MESH:D005013
-xref: PMID: 30408474
+xref: PMID:30408474
 is_a: XCO:0000269 ! calcium channel inhibitor
 created_by: slaulede
 creation_date: 2021-10-29T11:04:35Z
@@ -8910,7 +8909,7 @@ creation_date: 2021-10-29T11:04:35Z
 [Term]
 id: XCO:0000914
 name: cafeteria diet
-def: "A dietary regimen in which access to food is unlimited and consists of energy-dense, highly palatable food. The diet is technically undefined as to ratio of components, but recapitulates the orosensory properties (such as smell and texture) and palatability of foodstuffs that promote overconsumption (voluntary hyperphagia). It has been proven to not only increase body weight and induce obesity, but to also cause metabolic syndrome, severe diabetic symptoms, liver inflammation, and other metabolic dysregulations." [PMID: 33309818]
+def: "A dietary regimen in which access to food is unlimited and consists of energy-dense, highly palatable food. The diet is technically undefined as to ratio of components, but recapitulates the orosensory properties (such as smell and texture) and palatability of foodstuffs that promote overconsumption (voluntary hyperphagia). It has been proven to not only increase body weight and induce obesity, but to also cause metabolic syndrome, severe diabetic symptoms, liver inflammation, and other metabolic dysregulations." [PMID:33309818]
 synonym: "junk food diet" EXACT []
 synonym: "supermarket diet" EXACT []
 synonym: "Western diet" EXACT []

--- a/experimental_condition.obo
+++ b/experimental_condition.obo
@@ -8968,7 +8968,7 @@ synonym: "4-[methyl(nitroso)amino]butanoic acid" EXACT []
 synonym: "NMBA" EXACT []
 synonym: "N-nitrosomethylaminobutyric acid" EXACT []
 synonym: "N-nitrosomethylbenzylamine" EXACT []
-xref: CID:13643
+xref: pubchem.compound:13643
 xref: PMID:32123074
 is_a: XCO:0000089 ! neoplasm-inducing chemical
 created_by: slaulede
@@ -9275,7 +9275,7 @@ synonym: "(2R4-[(2E)-3-phosphonoprop-2-en-1-yl]piperazine-2-carboxylic acid" EXA
 synonym: "CPPene" EXACT []
 synonym: "D-Cpp-ene" EXACT []
 synonym: "SDZ EAA 494" EXACT []
-xref: CID:6435801
+xref: pubchem.compound:6435801
 xref: PMID:32507787
 is_a: XCO:0000947 ! NMDA receptor antagonist
 created_by: slaulede


### PR DESCRIPTION
This PR does the following:

1. Fixes assorted typos (e.g., whitespace inside CURIEs)
2. Standardizes prefixes (e.g., `Pubchem` -> `pubchem.compound`)
3. Turns synonyms into xrefs (e.g., `synonym: "CHEBI:7565" EXACT []` -> `xref: CHEBI:7565`)